### PR TITLE
Adds longString Control

### DIFF
--- a/examples/DropboxExample.elm
+++ b/examples/DropboxExample.elm
@@ -52,7 +52,7 @@ init =
                 (Control.maybe False <| Control.date Time.utc <| Time.millisToPosix 0)
             |> Control.field "mute" (Control.bool False)
             |> Control.field "content"
-                (Control.longString
+                (Control.stringTextarea
                     """I do much wonder that one man, seeing how much
 another man is a fool when he dedicates his
 behaviors to love, will, after he hath laughed at
@@ -142,7 +142,7 @@ record UploadRequest
         (maybe False <| date Tim.utc <| Time.millisToPosix 0)
     |> field "mute" (bool False)
     |> field "content"
-        (Control.longString
+        (Control.stringTextarea
             \"\"\"I do much wonder that one man, seeing how much
 another man is a fool when he dedicates his
 behaviors to love, will, after he hath laughed at

--- a/examples/DropboxExample.elm
+++ b/examples/DropboxExample.elm
@@ -51,7 +51,21 @@ init =
             |> Control.field "clientModified"
                 (Control.maybe False <| Control.date Time.utc <| Time.millisToPosix 0)
             |> Control.field "mute" (Control.bool False)
-            |> Control.field "content" (Control.string "HELLO.")
+            |> Control.field "content"
+                (Control.longString
+                    """I do much wonder that one man, seeing how much
+another man is a fool when he dedicates his
+behaviors to love, will, after he hath laughed at
+such shallow follies in others, become the argument
+of his own scorn by failing in love: and such a man
+is Claudio. I have known when there was no music
+with him but the drum and the fife; and now had he
+rather hear the tabour and the pipe: I have known
+when he would have walked ten mile a-foot to see a
+good armour; and now will he lie ten nights awake,
+carving the fashion of a new doublet.
+"""
+                )
     }
 
 
@@ -127,6 +141,21 @@ record UploadRequest
     |> field "clientModified"
         (maybe False <| date Tim.utc <| Time.millisToPosix 0)
     |> field "mute" (bool False)
-    |> field "content" (string "HELLO.")""" ]
+    |> field "content"
+        (Control.longString
+            \"\"\"I do much wonder that one man, seeing how much
+another man is a fool when he dedicates his
+behaviors to love, will, after he hath laughed at
+such shallow follies in others, become the argument
+of his own scorn by failing in love: and such a man
+is Claudio. I have known when there was no music
+with him but the drum and the fife; and now had he
+rather hear the tabour and the pipe: I have known
+when he would have walked ten mile a-foot to see a
+good armour; and now will he lie ten nights awake,
+carving the fashion of a new doublet.
+\"\"\"
+        )
+                """ ]
         , Control.view UploadChange model.upload
         ]

--- a/src/Debug/Control.elm
+++ b/src/Debug/Control.elm
@@ -1,7 +1,7 @@
 module Debug.Control exposing
     ( Control
     , value
-    , bool, string, date
+    , bool, string, longString, date
     , values, maybe, choice, list, record, field
     , map
     , view, currentValue, allValues
@@ -12,7 +12,7 @@ module Debug.Control exposing
 
 @docs Control
 @docs value
-@docs bool, string, date
+@docs bool, string, longString, date
 @docs values, maybe, choice, list, record, field
 @docs map
 
@@ -164,6 +164,39 @@ string initialValue =
                     Html.input
                         [ Html.Attributes.value initialValue
                         , Html.Events.onInput string
+                        ]
+                        []
+        }
+
+
+{-| A `Control` that allows multiline text input.
+-}
+longString : String -> Control String
+longString initialValue =
+    Control
+        { currentValue = \() -> initialValue
+        , allValues =
+            \() ->
+                [ initialValue
+                , ""
+                , "short"
+                , "Longwordyesverylongwithnospacessupercalifragilisticexpialidocious"
+                , """
+                    Long text lorem ipsum dolor sit amet, consectetur adipiscing elit,
+                    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+                    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+                    nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+                    reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                  """
+                ]
+        , view =
+            \() ->
+                SingleView <|
+                    Html.textarea
+                        [ Html.Attributes.value initialValue
+                        , Html.Events.onInput longString
                         ]
                         []
         }

--- a/src/Debug/Control.elm
+++ b/src/Debug/Control.elm
@@ -1,7 +1,7 @@
 module Debug.Control exposing
     ( Control
     , value
-    , bool, string, longString, date
+    , bool, string, stringTextarea, date
     , values, maybe, choice, list, record, field
     , map
     , view, currentValue, allValues
@@ -12,7 +12,7 @@ module Debug.Control exposing
 
 @docs Control
 @docs value
-@docs bool, string, longString, date
+@docs bool, string, stringTextarea, date
 @docs values, maybe, choice, list, record, field
 @docs map
 
@@ -171,8 +171,8 @@ string initialValue =
 
 {-| A `Control` that allows multiline text input.
 -}
-longString : String -> Control String
-longString initialValue =
+stringTextarea : String -> Control String
+stringTextarea initialValue =
     Control
         { currentValue = \() -> initialValue
         , allValues =
@@ -196,7 +196,7 @@ longString initialValue =
                 SingleView <|
                     Html.textarea
                         [ Html.Attributes.value initialValue
-                        , Html.Events.onInput longString
+                        , Html.Events.onInput stringTextarea
                         ]
                         []
         }

--- a/tests/Controls/StringTest.elm
+++ b/tests/Controls/StringTest.elm
@@ -9,22 +9,33 @@ import Test.Html.Query as Query
 import Test.Html.Selector exposing (..)
 
 
-stringControls =
-    Control.string "default"
-
-
 all : Test
 all =
-    describe "Control.string"
-        [ test "initial value" <|
-            \() ->
-                stringControls
-                    |> Control.currentValue
-                    |> Expect.equal "default"
-        , test "Renders all options" <|
-            \() ->
-                stringControls
-                    |> Control.view identity
-                    |> Query.fromHtml
-                    |> Query.has [ tag "input", attribute (Html.value "default") ]
+    describe "Text"
+        [ describe "Control.string"
+            [ test "initial value" <|
+                \() ->
+                    Control.string "default"
+                        |> Control.currentValue
+                        |> Expect.equal "default"
+            , test "Renders all options" <|
+                \() ->
+                    Control.string "default"
+                        |> Control.view identity
+                        |> Query.fromHtml
+                        |> Query.has [ tag "input", attribute (Html.value "default") ]
+            ]
+        , describe "Control.longString"
+            [ test "initial value" <|
+                \() ->
+                    Control.longString "long default"
+                        |> Control.currentValue
+                        |> Expect.equal "long default"
+            , test "Renders all options" <|
+                \() ->
+                    Control.longString "long default"
+                        |> Control.view identity
+                        |> Query.fromHtml
+                        |> Query.has [ tag "textarea", attribute (Html.value "long default") ]
+            ]
         ]

--- a/tests/Controls/StringTest.elm
+++ b/tests/Controls/StringTest.elm
@@ -25,15 +25,15 @@ all =
                         |> Query.fromHtml
                         |> Query.has [ tag "input", attribute (Html.value "default") ]
             ]
-        , describe "Control.longString"
+        , describe "Control.stringTextarea"
             [ test "initial value" <|
                 \() ->
-                    Control.longString "long default"
+                    Control.stringTextarea "long default"
                         |> Control.currentValue
                         |> Expect.equal "long default"
             , test "Renders all options" <|
                 \() ->
-                    Control.longString "long default"
+                    Control.stringTextarea "long default"
                         |> Control.view identity
                         |> Query.fromHtml
                         |> Query.has [ tag "textarea", attribute (Html.value "long default") ]


### PR DESCRIPTION
Adds a text area control, to support multi-line text. I called it longString -- maybe multilineString would be better?

<img width="605" alt="Screen Shot 2019-09-10 at 12 22 16 PM" src="https://user-images.githubusercontent.com/8811312/64643655-b4fcdf80-d3c5-11e9-92a9-6688013baeb4.png">